### PR TITLE
Updated external.gyp

### DIFF
--- a/ion/external/external.gyp
+++ b/ion/external/external.gyp
@@ -303,6 +303,8 @@
       ],
       'defines': [
         'STDC',
+        'NOCRYPT=1'
+        'NOUNCRYPT=1'
       ],
       'all_dependent_settings': {
         'include_dirs': [


### PR DESCRIPTION
Zlib was not building on iOS. Adding `NOCRYPT=1` and `NOUNCRYPT=1` fixes the problem. The demos still work.